### PR TITLE
bad raspberry pi detection

### DIFF
--- a/hwio.go
+++ b/hwio.go
@@ -66,7 +66,7 @@ func determineDriver() {
 	s := string(uname)
 	if strings.Contains(s, "beaglebone") {
 		SetDriver(new(BeagleBoneDriver))
-	} else if strings.Contains(s, "raspberrypi") && strings.Contains(s, "adafruit") {
+	} else if strings.Contains(s, "raspberrypi") || strings.Contains(s, "adafruit") {
 		SetDriver(new(RaspberryPiDriver))
 	}
 }


### PR DESCRIPTION
HWIO wasn't working on my Raspberry Pi ; after some debugging, it turned out hwio.go was looking for the "raspberry" AND "adafruit" substring in the result of "uname -a". If I got it correctly, it should be "raspberry" OR "adafruit".
