### PR TITLE
Use GOPATH relative import paths

### DIFF
--- a/examples/blink.go
+++ b/examples/blink.go
@@ -7,8 +7,9 @@ package main
 
 import (
 	"fmt"
-	"hwio"
 	"os"
+
+	"github.com/mrmorphic/hwio"
 )
 
 func main() {

--- a/examples/pinmap.go
+++ b/examples/pinmap.go
@@ -7,7 +7,7 @@
 package main
 
 import (
-	"hwio"
+	"github.com/mrmorphic/hwio"
 )
 
 func main() {

--- a/examples/shiftout.go
+++ b/examples/shiftout.go
@@ -4,7 +4,7 @@ package main
 // Implements a continuous 8-bit binary counter.
 
 import (
-	"hwio"
+	"github.com/mrmorphic/hwio"
 )
 
 func main() {

--- a/examples/tlc5940.go
+++ b/examples/tlc5940.go
@@ -5,7 +5,8 @@ package main
 
 import (
 	"fmt"
-	"hwio"
+
+	"github.com/mrmorphic/hwio"
 )
 
 func main() {


### PR DESCRIPTION
When using 

```
go get github.com/mirmorphic/hwio
```

 I am unable to get the examples to compile because the import paths assume hwio is relative to GOPATH/src. It would be really helpful if we could follow the go convention of using the public go repo paths, because then I can run the examples using go run. e.g.

```
go run examples/pinmap.go
```

I checked Dave Cheney's gpio project and his examples seem to use this convention. I've tested this change on a live BBB using Arch Linux. Many Thanks.
