### PR TITLE
Adding missing method to mock driver

### DIFF
--- a/driver_mock.go
+++ b/driver_mock.go
@@ -32,6 +32,10 @@ func (d *TestDriver) Close() {
 
 }
 
+func (d *TestDriver) MatchesHardwareConfig() bool {
+	return true
+}
+
 // func (d *TestDriver) SetVerbosity(verbose bool) {
 // 	d.verbose = verbose
 // }


### PR DESCRIPTION
Hi

I added this method to the mock driver so it implements the interface `HardwareDriver`