### PR TITLE
Detect Raspberry PI using Cpuinfo

### DIFF
--- a/driver_pi_dt.go
+++ b/driver_pi_dt.go
@@ -249,6 +249,13 @@ func (d *RaspberryPiDTDriver) BoardRevision() int {
 		return 3
 	}
 
+	// Pi 2 boards have different strings, but pinout is the same as B+
+	revision := CpuInfo(0, "CPU revision")
+	switch revision {
+	case "5":
+		return 3
+	}
+
 	return 2
 }
 

--- a/driver_pi_dt.go
+++ b/driver_pi_dt.go
@@ -31,17 +31,16 @@ func NewRaspPiDTDriver() *RaspberryPiDTDriver {
 	return &RaspberryPiDTDriver{}
 }
 
-// @todo determine a better way to detect the raspberry pi that is not dependent on uname
 func (d *RaspberryPiDTDriver) MatchesHardwareConfig() bool {
-	uname, e := exec.Command("uname", "-a").Output()
+	cpuinfo, e := exec.Command("cat", "/proc/cpuinfo").Output()
 	if e != nil {
 		return false
 	}
-
-	s := string(uname)
-	if strings.Contains(s, "raspberrypi") || strings.Contains(s, "adafruit") || strings.Contains(s, "alarmpi") {
+	s := string(cpuinfo)
+	if strings.Contains(s, "BCM2708") || strings.Contains(s, "BCM2709") {
 		return true
 	}
+
 	return false
 }
 


### PR DESCRIPTION
Because kernels may not have special strings embedded in uname, detect if we are
running based on Hardware field in /proc/cpuinfo.